### PR TITLE
Document persistent hosting setup for WannCannaBis

### DIFF
--- a/README_DE.txt
+++ b/README_DE.txt
@@ -1,13 +1,32 @@
 
 WannCannaBis – Termin- und Angebots-App
 
-Start (Windows):
-1) Node.js installieren: https://nodejs.org/
-2) ZIP entpacken.
-3) run_windows.bat starten.
-4) Browser: http://localhost:3000
+## Lokaler Start (Windows)
+1. Node.js installieren: https://nodejs.org/
+2. ZIP entpacken.
+3. `npm install` im Projektordner ausführen, um Abhängigkeiten (inkl. PostgreSQL-Treiber) zu installieren.
+4. `run_windows.bat` starten **oder** `npm start` im Terminal ausführen.
+5. Browser öffnen: http://localhost:3000
 
-Admin:
-- Login: /admin  (Standard: admin / admin1234!)
+## Admin-Zugang
+- Login: `/admin`  (Standard: `admin` / `admin1234!`)
 - Schlüssel erstellen: Code + Gültigkeitstage.
 - Verkäufer müssen bei Registrierung den Schlüssel angeben. Zugang läuft zum Schlüssel-Ablauf aus.
+
+## Dauerhafter Betrieb & persistente Speicherung
+Damit Eingaben auch nach langen Pausen erhalten bleiben und die Anwendung dauerhaft online erreichbar ist, sollte sie auf einem Hosting-Anbieter mit dauerhaften Diensten betrieben werden. Ein möglicher Weg ist der Einsatz von [Render](https://render.com/) mit einer angebundenen PostgreSQL-Datenbank.
+
+### Schritte für Render
+1. Repository zu GitHub hochladen oder ein öffentliches Repo nutzen.
+2. Bei Render einen **Web Service** mit "Node" als Runtime anlegen und das Repository verbinden.
+3. Unter "Build Command" `npm install` und unter "Start Command" `npm start` eintragen.
+4. Zusätzlich in Render einen **PostgreSQL**-Dienst anlegen. Render erzeugt automatisch die Umgebungsvariable `DATABASE_URL`.
+5. Auf der Service-Seite unter "Environment" die Variable `DATABASE_URL` vom Datenbank-Dienst verknüpfen (Render bietet hierfür einen Button "Add Environment Variable from Service" an).
+6. Deploy starten. Beim Hochfahren initialisiert `server.js` die Tabelle `app_data` und repliziert die bestehenden Daten automatisch in die Datenbank.
+
+Sobald die Anwendung läuft, werden alle Änderungen weiterhin lokal in `data.json` geschrieben **und** asynchron in die Datenbank übernommen. Nach einem Neustart – etwa durch ein neues Deployment – werden die Daten wieder aus PostgreSQL geladen und stehen sofort zur Verfügung.
+
+### Hinweise für andere Hosting-Plattformen
+- Wichtig ist, dass der Host die Umgebungsvariable `DATABASE_URL` bereitstellt und dauerhaft einen Node.js-Prozess laufen lässt.
+- Falls kein dauerhafter Dateispeicher vorhanden ist (z. B. bei Serverless-Anbietern), stellt die PostgreSQL-Datenbank sicher, dass die Daten trotzdem nicht verloren gehen.
+- Für einen 24/7-Betrieb empfiehlt sich ein Tarif ohne Sleep-Modus.

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: wanncannabis-app
+    env: node
+    plan: starter
+    buildCommand: npm install
+    startCommand: npm start
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: wanncannabis-db
+          property: connectionString
+    autoDeploy: true
+    healthCheckPath: /
+databases:
+  - name: wanncannabis-db
+    plan: starter


### PR DESCRIPTION
## Summary
- update the German README with detailed instructions for running the app locally and deploying it with persistent PostgreSQL storage on Render
- add a Render blueprint file that provisions a web service and managed database so the application stays online and retains data across restarts

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d6e45be8608323afe2463649e9027a